### PR TITLE
VCST-1907: Fixed the link to the project repository in the manifest

### DIFF
--- a/src/VirtoCommerce.XCMS.Web/module.manifest
+++ b/src/VirtoCommerce.XCMS.Web/module.manifest
@@ -34,7 +34,7 @@
     <group>commerce</group>
   </groups>
 
-  <projectUrl>https://github.com/VirtoCommerce/vc-module-xcms</projectUrl>
+  <projectUrl>https://github.com/VirtoCommerce/vc-module-x-cms</projectUrl>
   <iconUrl>Modules/$(VirtoCommerce.XCMS)/Content/logo.png</iconUrl>
   <requireLicenseAcceptance>false</requireLicenseAcceptance>
 


### PR DESCRIPTION
## Description
fix: Fixed the link to the project repository in the module manifest file

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-1907
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.XCMS_3.801.0-pr-3-c601.zip