### PR TITLE
fix graph override bug for menuLink Types

### DIFF
--- a/src/VirtoCommerce.XCMS.Core/Schemas/MenuLinkListType.cs
+++ b/src/VirtoCommerce.XCMS.Core/Schemas/MenuLinkListType.cs
@@ -1,4 +1,6 @@
+using GraphQL.Resolvers;
 using GraphQL.Types;
+using VirtoCommerce.Xapi.Core.Helpers;
 using VirtoCommerce.XCMS.Core.Models;
 
 namespace VirtoCommerce.XCMS.Core.Schemas
@@ -9,7 +11,12 @@ namespace VirtoCommerce.XCMS.Core.Schemas
         {
             Field(x => x.Name, nullable: false).Description("Menu name");
             Field(x => x.OuterId, nullable: true).Description("Menu outer ID");
-            Field<NonNullGraphType<ListGraphType<NonNullGraphType<MenuLinkType>>>>("items", resolve: context => context.Source.Items);
+            AddField(new FieldType
+            {
+                Name = "items",
+                Type = GraphTypeExtenstionHelper.GetActualComplexType<NonNullGraphType<ListGraphType<NonNullGraphType<MenuLinkType>>>>(),
+                Resolver = new FuncFieldResolver<Menu, object>(context => context.Source?.Items)
+            });
         }
     }
 }

--- a/src/VirtoCommerce.XCMS.Core/Schemas/MenuLinkType.cs
+++ b/src/VirtoCommerce.XCMS.Core/Schemas/MenuLinkType.cs
@@ -1,4 +1,6 @@
+using GraphQL.Resolvers;
 using GraphQL.Types;
+using VirtoCommerce.Xapi.Core.Helpers;
 using VirtoCommerce.XCMS.Core.Models;
 
 namespace VirtoCommerce.XCMS.Core.Schemas
@@ -14,7 +16,12 @@ namespace VirtoCommerce.XCMS.Core.Schemas
             Field(x => x.Link.AssociatedObjectName, nullable: true).Description("Menu item object name");
             Field(x => x.Link.AssociatedObjectType, nullable: true).Description("Menu item type name");
             Field(x => x.Link.OuterId, nullable: true).Description("Menu item outerID");
-            Field<NonNullGraphType<ListGraphType<NonNullGraphType<MenuLinkType>>>>(nameof(MenuItem.ChildItems), resolve: context => context.Source.ChildItems);
+            AddField(new FieldType
+            {
+                Name = nameof(MenuItem.ChildItems),
+                Type = GraphTypeExtenstionHelper.GetActualComplexType<NonNullGraphType<ListGraphType<NonNullGraphType<MenuLinkType>>>>(),
+                Resolver = new FuncFieldResolver<MenuItem, object>(context => context.Source?.ChildItems)
+            });
         }
     }
 }


### PR DESCRIPTION
## Description
the current implementation for the `MenuLinkType `and `MenuLinkListType `does not support type override. 

for example if the MenuLinkType got overridden using `serviceCollection.AddSchemaType<MenuLinkTypeExtend>().OverrideType<MenuLinkType, MenuLinkTypeExtend>();` it won't work and the schema will still show the base type.

this pull request makes sure to fetch the correct type if the base type is overridden.