### PR TITLE
VCST-4328: Bump page builder reference to 3.1000

### DIFF
--- a/src/VirtoCommerce.XCMS.Core/VirtoCommerce.XCMS.Core.csproj
+++ b/src/VirtoCommerce.XCMS.Core/VirtoCommerce.XCMS.Core.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="VirtoCommerce.ContentModule.Core" Version="3.1000.0" />
     <PackageReference Include="VirtoCommerce.CustomerModule.Core" Version="3.1000.0" />
-    <PackageReference Include="VirtoCommerce.PageBuilderModule.Core" Version="3.835.0" />
+    <PackageReference Include="VirtoCommerce.PageBuilderModule.Core" Version="3.1000.0" />
     <PackageReference Include="VirtoCommerce.Pages.Core" Version="3.1000.0" />
     <PackageReference Include="VirtoCommerce.Xapi.Core" Version="3.1000.0" />
   </ItemGroup>

--- a/src/VirtoCommerce.XCMS.Web/module.manifest
+++ b/src/VirtoCommerce.XCMS.Web/module.manifest
@@ -10,7 +10,7 @@
     <dependency id="VirtoCommerce.Content" version="3.1000.0" />
     <dependency id="VirtoCommerce.Customer" version="3.1000.0" />
     <dependency id="VirtoCommerce.Pages" version="3.1000.0" optional="true" />
-    <dependency id="VirtoCommerce.PageBuilderModule" version="3.835.0" optional="true" />
+    <dependency id="VirtoCommerce.PageBuilderModule" version="3.1000.0" optional="true" />
   </dependencies>
 
   <title>CMS Experience API</title>


### PR DESCRIPTION
## Description
feat: Bump page builder reference to 3.1000

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-4328
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.XCMS_3.1001.0-pr-20-4a41.zip
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency bump limited to version alignment of the optional Page Builder module; potential risk is runtime incompatibility if the new PageBuilder version has breaking changes.
> 
> **Overview**
> Aligns the CMS module’s Page Builder dependency to the `3.1000.0` release.
> 
> This updates both the NuGet reference (`VirtoCommerce.PageBuilderModule.Core`) and the module manifest dependency (`VirtoCommerce.PageBuilderModule`) from `3.835.0` to `3.1000.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4a41eff2c4cbbd60ceec979cec25afc441eb830d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->