### PR TITLE
VCST-5163: Stable 15 — XCMS (platform 3.1039.0)

### DIFF
--- a/src/VirtoCommerce.XCMS.Core/VirtoCommerce.XCMS.Core.csproj
+++ b/src/VirtoCommerce.XCMS.Core/VirtoCommerce.XCMS.Core.csproj
@@ -8,10 +8,10 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="VirtoCommerce.ContentModule.Core" Version="3.1000.0" />
-    <PackageReference Include="VirtoCommerce.CustomerModule.Core" Version="3.1000.0" />
-    <PackageReference Include="VirtoCommerce.PageBuilderModule.Core" Version="3.1000.0" />
-    <PackageReference Include="VirtoCommerce.Pages.Core" Version="3.1000.0" />
-    <PackageReference Include="VirtoCommerce.Xapi.Core" Version="3.1000.0" />
+    <PackageReference Include="VirtoCommerce.ContentModule.Core" Version="3.1003.0" />
+    <PackageReference Include="VirtoCommerce.CustomerModule.Core" Version="3.1011.0" />
+    <PackageReference Include="VirtoCommerce.PageBuilderModule.Core" Version="3.1012.0" />
+    <PackageReference Include="VirtoCommerce.Pages.Core" Version="3.1007.0" />
+    <PackageReference Include="VirtoCommerce.Xapi.Core" Version="3.1012.0" />
   </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.XCMS.Web/module.manifest
+++ b/src/VirtoCommerce.XCMS.Web/module.manifest
@@ -4,13 +4,13 @@
   <version>3.1003.0</version>
   <version-tag></version-tag>
 
-  <platformVersion>3.1007.10</platformVersion>
+  <platformVersion>3.1039.0</platformVersion>
   <dependencies>
-    <dependency id="VirtoCommerce.Xapi" version="3.1000.0" />
-    <dependency id="VirtoCommerce.Content" version="3.1000.0" />
-    <dependency id="VirtoCommerce.Customer" version="3.1000.0" />
-    <dependency id="VirtoCommerce.Pages" version="3.1000.0" optional="true" />
-    <dependency id="VirtoCommerce.PageBuilderModule" version="3.1000.0" optional="true" />
+    <dependency id="VirtoCommerce.Xapi" version="3.1012.0" />
+    <dependency id="VirtoCommerce.Content" version="3.1003.0" />
+    <dependency id="VirtoCommerce.Customer" version="3.1011.0" />
+    <dependency id="VirtoCommerce.Pages" version="3.1007.0" optional="true" />
+    <dependency id="VirtoCommerce.PageBuilderModule" version="3.1012.0" optional="true" />
   </dependencies>
 
   <title>CMS Experience API</title>

--- a/tests/VirtoCommerce.XCMS.Tests/VirtoCommerce.XCMS.Tests.csproj
+++ b/tests/VirtoCommerce.XCMS.Tests/VirtoCommerce.XCMS.Tests.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.18.1" />
-    <PackageReference Include="coverlet.collector" Version="8.0.0">
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
Part of **Stable 15** (Wave 7). Builds against published platform [3.1039.0](https://github.com/VirtoCommerce/vc-platform/releases/tag/3.1039.0) + Waves 1–6 packages on nuget.org. Version handled by CI.

- deps bumped: Xapi 3.1012.0, Customer 3.1011.0.
- `vc-build Compress` green incl. unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only alignment for platform and NuGet dependencies plus a test coverage tool bump; no runtime logic changes in this diff.
> 
> **Overview**
> Aligns **VirtoCommerce.XCMS** with **Stable 15** by targeting platform **3.1039.0** and bumping VirtoCommerce module NuGet references from the **3.1000.0** baseline to published Wave 1–6 versions.
> 
> In `VirtoCommerce.XCMS.Core.csproj`, **ContentModule.Core** → **3.1003.0**, **CustomerModule.Core** → **3.1011.0**, **PageBuilderModule.Core** → **3.1012.0**, **Pages.Core** → **3.1007.0**, and **Xapi.Core** → **3.1012.0**. `module.manifest` updates **`platformVersion`** from **3.1007.10** to **3.1039.0** and matches the same dependency versions for **Xapi**, **Content**, **Customer**, **Pages**, and **PageBuilderModule**.
> 
> The test project only bumps **coverlet.collector** from **8.0.0** to **10.0.1**; no application code changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 681b535245010e1ab7c176af4d6ffae8758ed43f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5163
Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.XCMS_3.1003.0-pr-21-681b.zip