### PR TITLE
VCST-5468: Resolve mediators per request

### DIFF
--- a/src/VirtoCommerce.XCMS.Core/VirtoCommerce.XCMS.Core.csproj
+++ b/src/VirtoCommerce.XCMS.Core/VirtoCommerce.XCMS.Core.csproj
@@ -12,6 +12,6 @@
     <PackageReference Include="VirtoCommerce.CustomerModule.Core" Version="3.1011.0" />
     <PackageReference Include="VirtoCommerce.PageBuilderModule.Core" Version="3.1012.0" />
     <PackageReference Include="VirtoCommerce.Pages.Core" Version="3.1007.0" />
-    <PackageReference Include="VirtoCommerce.Xapi.Core" Version="3.1012.0" />
+    <PackageReference Include="VirtoCommerce.Xapi.Core" Version="3.1015.0" />
   </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.XCMS.Data/Schemas/BuilderPageSchema.cs
+++ b/src/VirtoCommerce.XCMS.Data/Schemas/BuilderPageSchema.cs
@@ -14,8 +14,18 @@ using VirtoCommerce.XCMS.Core.Schemas;
 
 namespace VirtoCommerce.XCMS.Data.Schemas;
 
-public class BuilderPageSchema(IMediator mediator): ISchemaBuilder
+public class BuilderPageSchema : ISchemaBuilder
 {
+    public BuilderPageSchema()
+    {
+    }
+
+    [Obsolete("Use the constructor without IMediator. The mediator is resolved from context.RequestServices per request.", DiagnosticId = "VC0015", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
+    public BuilderPageSchema(IMediator mediator)
+        : this()
+    {
+    }
+
     public void Build(ISchema schema)
     {
         _ = schema.Query.AddField(new FieldType
@@ -30,7 +40,7 @@ public class BuilderPageSchema(IMediator mediator): ISchemaBuilder
             {
                 context.CopyArgumentsToUserContext();
 
-                var result = await mediator.Send(new GetBuilderPageQuery
+                var result = await context.GetMediator().Send(new GetBuilderPageQuery
                 {
                     StoreId = context.GetArgument<string>("storeId"),
                     PageId = context.GetArgument<string>("pageId"),

--- a/src/VirtoCommerce.XCMS.Data/Schemas/ContentSchema.cs
+++ b/src/VirtoCommerce.XCMS.Data/Schemas/ContentSchema.cs
@@ -17,11 +17,14 @@ namespace VirtoCommerce.XCMS.Data.Schemas
 {
     public class ContentSchema : ISchemaBuilder
     {
-        private readonly IMediator _mediator;
-
-        public ContentSchema(IMediator mediator)
+        public ContentSchema()
         {
-            _mediator = mediator;
+        }
+
+        [Obsolete("Use the constructor without IMediator. The mediator is resolved from context.RequestServices per request.", DiagnosticId = "VC0015", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
+        public ContentSchema(IMediator mediator)
+            : this()
+        {
         }
 
         public void Build(ISchema schema)
@@ -37,7 +40,7 @@ namespace VirtoCommerce.XCMS.Data.Schemas
                 Type = GraphTypeExtensionHelper.GetActualType<MenuLinkListType>(),
                 Resolver = new FuncFieldResolver<object>(async context =>
                 {
-                    var result = await _mediator.Send(new GetMenuQuery
+                    var result = await context.GetMediator().Send(new GetMenuQuery
                     {
                         StoreId = context.GetArgument<string>("storeId"),
                         CultureName = context.GetArgument<string>("cultureName"),
@@ -59,7 +62,7 @@ namespace VirtoCommerce.XCMS.Data.Schemas
                 Type = GraphTypeExtensionHelper.GetActualType<NonNullGraphType<ListGraphType<NonNullGraphType<MenuLinkListType>>>>(),
                 Resolver = new FuncFieldResolver<object>(async context =>
                 {
-                    var result = await _mediator.Send(new GetMenusQuery
+                    var result = await context.GetMediator().Send(new GetMenusQuery
                     {
                         StoreId = context.GetArgument<string>("storeId"),
                         CultureName = context.GetArgument<string>("cultureName"),
@@ -83,7 +86,7 @@ namespace VirtoCommerce.XCMS.Data.Schemas
                 {
                     context.CopyArgumentsToUserContext();
 
-                    var result = await _mediator.Send(new GetSinglePageQuery
+                    var result = await context.GetMediator().Send(new GetSinglePageQuery
                     {
                         StoreId = context.GetArgument<string>("storeId"),
                         CultureName = context.GetArgument<string>("cultureName"),
@@ -124,7 +127,7 @@ namespace VirtoCommerce.XCMS.Data.Schemas
                 Keyword = context.GetArgument<string>("keyword"),
             };
 
-            var response = await _mediator.Send(query);
+            var response = await context.GetMediator().Send(query);
 
             return new PagedConnection<PageItem>(response.Pages, query.Skip, query.Take, response.TotalCount);
         }

--- a/src/VirtoCommerce.XCMS.Data/Schemas/PageDocumentSchema.cs
+++ b/src/VirtoCommerce.XCMS.Data/Schemas/PageDocumentSchema.cs
@@ -15,8 +15,18 @@ using static VirtoCommerce.Xapi.Core.ModuleConstants;
 
 namespace VirtoCommerce.XCMS.Data.Schemas
 {
-    public class PageDocumentSchema(IMediator mediator) : ISchemaBuilder
+    public class PageDocumentSchema : ISchemaBuilder
     {
+        public PageDocumentSchema()
+        {
+        }
+
+        [Obsolete("Use the constructor without IMediator. The mediator is resolved from context.RequestServices per request.", DiagnosticId = "VC0015", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
+        public PageDocumentSchema(IMediator mediator)
+            : this()
+        {
+        }
+
         public void Build(ISchema schema)
         {
             _ = schema.Query.AddField(new FieldType
@@ -30,7 +40,7 @@ namespace VirtoCommerce.XCMS.Data.Schemas
                 {
                     context.CopyArgumentsToUserContext();
 
-                    var result = await mediator.Send(new GetSinglePageDocumentQuery
+                    var result = await context.GetMediator().Send(new GetSinglePageDocumentQuery
                     {
                         OrganizationId = context.GetCurrentOrganizationId(),
                         UserId = context.GetCurrentUserId(),
@@ -70,7 +80,7 @@ namespace VirtoCommerce.XCMS.Data.Schemas
                 UserId = context.GetCurrentUserId(),
             };
 
-            var response = await mediator.Send(query);
+            var response = await context.GetMediator().Send(query);
 
             return new PagedConnection<PageDocument>(response.Pages, query.Skip, query.Take, response.TotalCount);
         }

--- a/src/VirtoCommerce.XCMS.Web/module.manifest
+++ b/src/VirtoCommerce.XCMS.Web/module.manifest
@@ -6,7 +6,7 @@
 
   <platformVersion>3.1039.0</platformVersion>
   <dependencies>
-    <dependency id="VirtoCommerce.Xapi" version="3.1012.0" />
+    <dependency id="VirtoCommerce.Xapi" version="3.1015.0" />
     <dependency id="VirtoCommerce.Content" version="3.1003.0" />
     <dependency id="VirtoCommerce.Customer" version="3.1011.0" />
     <dependency id="VirtoCommerce.Pages" version="3.1007.0" optional="true" />


### PR DESCRIPTION
## Description

GraphQL schema builders are created once while the schema is built. Injecting `IMediator` into their constructors captures the root service provider; a request dispatched through it can therefore resolve scoped handler dependencies from the wrong scope.

This change upgrades XApi to `3.1015.0` and resolves the mediator from the active GraphQL request through `context.GetMediator()` immediately before dispatch. `BuilderPageSchema`, `ContentSchema`, and `PageDocumentSchema` now dispatch their queries through the request scope.

Existing constructors that accept `IMediator` remain as obsolete compatibility overloads. They delegate to the mediator-free constructors, so existing consumers continue to compile without retaining a mediator in a singleton.

## References
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5468

### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.XCMS_3.1004.0-alpha.78-vcst-5468.zip
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how every CMS GraphQL resolver gets MediatR and depends on XApi’s request-scoped `GetMediator()`; wrong scope handling could still affect user/org-scoped queries, but the change corrects a known singleton-capture bug.
> 
> **Overview**
> Fixes incorrect DI scoping for CMS GraphQL queries by **no longer injecting `IMediator` into schema builders** that are built once. **`BuilderPageSchema`**, **`ContentSchema`**, and **`PageDocumentSchema`** now call **`context.GetMediator()`** when resolving fields and connections so MediatR runs in the active request scope.
> 
> Bumps **VirtoCommerce.Xapi** / **`VirtoCommerce.Xapi.Core`** to **3.1015.0** (project reference and `module.manifest`). **`IMediator` constructors remain** as **`[Obsolete]`** overloads (VC0015) that delegate to parameterless constructors for binary compatibility.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d4a68144aa9b62c9850d36b42557b4f7cadc7de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->